### PR TITLE
Add cypress dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,6 +145,14 @@ RUN apt-get update && \
         libxml2-utils \
         libxslt-dev \
         libyaml-dev \
+        libgtk2.0-0t64 \
+        libgtk-3-0t64 \
+        libgbm-dev \
+        libnotify-dev \
+        libnss3 \
+        libxss1 \
+        libasound2t64 \
+        libxtst6 \
         make \
         mercurial \
         mutt \
@@ -162,6 +170,8 @@ RUN apt-get update && \
         wget \
         xmlstarlet \
         xz-utils \
+        xauth \
+        xvfb \
         yarn \
         zip \
         zlib1g-dev \


### PR DESCRIPTION
According cypress documentation, we need to add this dependencies.
https://docs.cypress.io/guides/getting-started/installing-cypress#Linux-Prerequisites

Alternatively, we can change and use different agents (example: 'cypress/base:20.14.0') that is specific for cypress work.
2nd option is totally different from what we use now :)